### PR TITLE
fix: update download links to Google Play Store in sidebar

### DIFF
--- a/src/components/sidebar/cta-sidebar.tsx
+++ b/src/components/sidebar/cta-sidebar.tsx
@@ -62,7 +62,8 @@ export default function CtaSidebar() {
               <Button
                 fullWidth
                 variant="contained"
-                href="https://storage.zenaiyoga.com/files/zenaiyoga-beta-v1_0.1.apk"
+                target="_blank"
+                href="https://play.google.com/store/apps/details?id=com.yogitech.yogi_application"
                 startIcon={<Iconify icon="ri:google-play-fill" />}
               >
                 {t("ctaSidebar.googlePlay")}

--- a/src/components/sidebar/mobile-banner.tsx
+++ b/src/components/sidebar/mobile-banner.tsx
@@ -68,8 +68,9 @@ export default function MobileBanner() {
           className="flex-none"
           variant="contained"
           size="small"
-          href="https://storage.zenaiyoga.com/files/zenaiyoga-beta-v1_0.1.apk"
-          startIcon={<Iconify icon="eva:download-fill" />}
+          target="_blank"
+          href="https://play.google.com/store/apps/details?id=com.yogitech.yogi_application"
+          startIcon={<Iconify icon="ri:google-play-fill" />}
         >
           {t("mobileBanner.getButton")}
         </Button>

--- a/src/sections/download/download-advertisement.tsx
+++ b/src/sections/download/download-advertisement.tsx
@@ -80,6 +80,30 @@ export default function DownloadAdvertisement() {
               {t("download.android")}
             </Button>
           </m.div>
+          <m.div variants={varFade().inRight}>
+            <Button
+              id="download-android"
+              color="inherit"
+              size="large"
+              target="_blank"
+              variant="contained"
+              rel="noopener"
+              href="https://play.google.com/store/apps/details?id=com.yogitech.yogi_application"
+              sx={{
+                color: "grey.800",
+                bgcolor: "common.white",
+                ":hover": {
+                  bgcolor: "common.white",
+                },
+              }}
+              startIcon={
+                <Iconify icon="mdi:google-play" width={24} sx={{ mr: 0 }} />
+              }
+            >
+              Play Store
+            </Button>
+          </m.div>
+
           <m.div variants={varFade().inRight} className="flex items-center">
             <span className="text-sm font-bold md:text-xl">
               👈


### PR DESCRIPTION
- Changed download links in CtaSidebar and MobileBanner components to point to the Google Play Store.
- Added a new button in DownloadAdvertisement for direct access to the Play Store, enhancing user experience.